### PR TITLE
Added filters to take more than one filter parameter, changed campus parameters

### DIFF
--- a/src/components/functions/termPageFilters.js
+++ b/src/components/functions/termPageFilters.js
@@ -1,13 +1,17 @@
 import { TermInfo } from "./termInfoFunctions";
 
+const filterByLevel = (termInfoList, level) => {
+    return termInfoList.filter(termInfo => termInfo.courseNumber.replace(/[^0-9]/g, '') >= level && termInfo.courseNumber.replace(/[^0-9]/g, '') < level+100);
+}
+
 /**
  * Function to filter a list of TermInfo objects according to it's level (100 level, 200 level, etc.)
  * @param {TermInfo[]} termInfoList List of TermInfo objects to filter
- * @param {number} level Course level to filter (100 level, 200 level, etc.)
+ * @param {number[]} levelList List of course levels to filter (100 level, 200 level, etc.)
  * @returns {TermInfo[]} List of filtered TermInfo objects
  */
-const filterByLevel = (termInfoList, level) => {
-    return termInfoList.filter(termInfo => termInfo.courseNumber >= level && termInfo.courseNumber < level+100);
+const filterByLevels = (termInfoList, levelList) => {
+    return levelList.map(level => filterByLevel(termInfoList, level)).reduce((accum, currVal) => accum.concat(currVal), [])
 }
 
 /**
@@ -21,14 +25,28 @@ const filterByInstructor = (termInfoList, instructor) => {
     return termInfoList.filter(termInfo => termInfo.instructor.toLowerCase().includes(instructor.toLowerCase()));
 }
 
+const filterByCampus = (termInfoList, campus) => {
+    if (campus.toLowerCase() == "online") {
+        return termInfoList.filter(termInfo => termInfo.courseSection.toLowerCase().includes("ol"));
+    } else if (campus.toLowerCase() == "other") {
+        return termInfoList.filter(termInfo => termInfo.campus.toLowerCase() != "burnaby" && termInfo.campus.toLowerCase() != "surrey" && termInfo.courseSection.toLowerCase().indexOf("ol") === -1);
+    } else {
+        return termInfoList.filter(termInfo => termInfo.campus.toLowerCase() == campus.toLowerCase());
+    }
+}
+
 /**
  * Function to filter a list of TermInfo objects according to it's campus
  * @param {TermInfo[]} termInfoList List of TermInfo objects to filter
- * @param {String} campus Campus location to filter (eg: "Burnaby")
+ * @param {String[]} campusList List of campus locations to filter (eg: "Burnaby")
  * @returns {TermInfo[]} List of filtered TermInfo objects
  */
-const filterByCampus = (termInfoList, campus) => {
-    return termInfoList.filter(termInfo => termInfo.campus.toLowerCase() == campus.toLowerCase());
+const filterByCampuses = (termInfoList, campusList) => {
+    return campusList.map(campus => filterByCampus(termInfoList, campus)).reduce((accum, currVal) => accum.concat(currVal), [])
+}
+
+const filterByWqb = (termInfoList, wqb) => {
+    return termInfoList.filter(termInfo => termInfo.wqb.toLowerCase().includes(wqb.toLowerCase().replace(/b-/g, "")));
 }
 
 /**
@@ -36,11 +54,11 @@ const filterByCampus = (termInfoList, campus) => {
  * Note: Function assumes only one designation as input (eg: "B-Sci" will work but "Q/W/B-Sci" might not work)
  * In the term page, filter wqbs one by one
  * @param {TermInfo[]} termInfoList List of TermInfo objects to filter 
- * @param {String} wqb WQB designation to filter
+ * @param {String[]} wqbList List of WQB designations to filter
  * @returns {TermInfo[]} List of filtered TermInfo objects
  */
-const filterByWqb = (termInfoList, wqb) => {
-    return termInfoList.filter(termInfo => termInfo.wqb.toLowerCase().includes(wqb.toLowerCase().replace(/b-/g, "")));
+const filterByWqbs = (termInfoList, wqbList) => {
+    return [... new Set(wqbList.map(wqb => filterByWqb(termInfoList, wqb)).reduce((accum, currVal) => accum.concat(currVal), []))] // Set notation removes duplicates
 }
 
 /**
@@ -52,3 +70,5 @@ const filterByWqb = (termInfoList, wqb) => {
 const filterByCredits = (termInfoList, credits) => {
     return termInfoList.filter(termInfo => termInfo.credits == credits);
 }
+
+export {filterByLevels, filterByCampuses, filterByWqbs, filterByInstructor, filterByCredits};


### PR DESCRIPTION
Added filter functions that now take more than one filter parameter as a list.

The filters that can take more than one filter parameter:

- Filter by Levels
- Filter by Campuses
- Filter by WQB Designations

All of these filters have checkbox parameters so we be able to filter with more than one parameter

The filters that doesn't take more than one filter parameters:

- Filter by Instructor
- Filter by Credits

Both of these filters are text input from the user so it doesn't make sense to have more than one filter parameter

I also made a change for campus filtering, now instead of taking a "Vancouver" option, the checkbox will show "Online" and "Other" instead. Reasoning is because there are multiple Vancouver campuses and all of them are encoded differently in the API, so we'd rather just bunch them together than deal with edge cases one by one